### PR TITLE
INPS su base imponibile effettiva (circolare 52 del 07-06-2023)

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -764,8 +764,8 @@ const regioneToRegola = {
 }
 
 function calcolaNetto(ral, regione, comune, hasAgevolazione, comuneDef) {
-    const inps = calcolaInps(ral);
     const baseImponibileEffettiva = baseImponibile(ral, regione, hasAgevolazione);
+    const inps = calcolaInps(hasAgevolazione? baseImponibileEffettiva : ral);
     const irpefTotale = calcolaIrpefTotale(baseImponibileEffettiva, regione, comune, comuneDef);
     const detrazioni = calcolaDetrazioni(baseImponibileEffettiva);
     const irpefNetto = calcolaIrpefNetto(irpefTotale, detrazioni);


### PR DESCRIPTION
Nella circolare 52 del 07-06-2023 l'INPS ha finalmente chiarito che anche i contributi (in gestione separata) sono da calcolare sulla stessa base imponibile usata ai fini IRPEF https://www.inps.it/it/it/inps-comunica/atti/circolari-messaggi-e-normativa/dettaglio.circolari-e-messaggi.2023.06.circolare-numero-52-del-07-06-2023_14174.html#:~:text=Per%20i%20liberi,n.%20111/2011